### PR TITLE
Write test for reproducing MTBLS520 parsing error.

### DIFF
--- a/isatools/isatab_meta.py
+++ b/isatools/isatab_meta.py
@@ -671,6 +671,16 @@ class InvestigationParser(AbstractParser):
         status_term_source = section.get(' '.join(
             [investigation_or_study_prefix, publication_prefix,
              status_prefix, self._term_source_ref_postfix]))
+
+        # None is refused by zip_longest(), since it requires iterable types.
+        # So we replace None values by empty lists.
+        if status is None:
+            status = []
+        if status_accession is None:
+            status_accession = []
+        if status_term_source is None:
+            status_term_source = []
+
         for p, d, a, t, s, s_acc, s_src in zip_longest(
                 pubmed_id, doi, author_list, title, status,
                 status_accession, status_term_source, fillvalue=''):

--- a/tests/test_isatab.py
+++ b/tests/test_isatab.py
@@ -910,6 +910,10 @@ class ParserIntegrationTest(unittest.TestCase):
             self.assertEqual(
                 len(self.parser.isa.studies[1].assays[-1].process_sequence), 30)
 
-    def test_parser_with_MTBLS30_2(self):
+    def test_parser_with_MTBLS30_w4m(self):
         self.parser.parse(os.path.join(
-            self._tab_data_dir, 'MTBLS30-2', 'i_Investigation.txt'))
+            self._tab_data_dir, 'MTBLS30-w4m', 'i_Investigation.txt'))
+
+    def test_parser_with_MTBLS520(self):
+        self.parser.parse(os.path.join(
+            self._tab_data_dir, 'MTBLS520', 'i_Investigation.txt'))

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist = py27, py36
 
 [testenv]
+deps = -rrequirements-tests.txt
 commands=py.test --basetemp=tests
 
 [travis]


### PR DESCRIPTION
Needs new ISA-tools/ISAdatasets version with tab/MTBLS520 study.
See issue #9 