### PR TITLE
Relax pinning of six

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         ],
     install_requires=[
         'networkx==1.11',
-        'six==1.11.0',
+        'six>=1.11.0',
     ],
     extras_require={
         'viz': ['matplotlib'],


### PR DESCRIPTION
Galaxy is pinning version 0.12 of six, so this leads to a conflict.
Instead of bumping the six dependency I think it makes sense to lift
this strict pin and just require a minimum six version.
There is still the requirements.txt files if more precise
environments are required.

I think this SO answer sums up my thinking pretty well: https://stackoverflow.com/a/44938662